### PR TITLE
Gpt 34 add geological contacts and metallogenic provinces layers

### DIFF
--- a/src/main/resources/config.properties
+++ b/src/main/resources/config.properties
@@ -45,6 +45,10 @@ WATERSHIP-NM.vocabService.url=http://auscope-services-test.arrc.csiro.au/sissvoc
 WATERSHIP-NM.googlemap.key=ABQIAAAAbNveSfm3KAg3Jlr8E0ByDRRAL775K1PSt7WjH6RqN-M1Q-XicxRL8_0cjY65r7C2fshtMXufTmK8og
 WATERSHIP-NM.maxFeatures.value=200
 
+PC-64606.vocabService.url=http://auscope-services-test.arrc.csiro.au/sissvoc/
+PC-64606.googlemap.key=ABQIAAAAbNveSfm3KAg3Jlr8E0ByDRRAL775K1PSt7WjH6RqN-M1Q-XicxRL8_0cjY65r7C2fshtMXufTmK8og
+PC-64606.maxFeatures.value=200
+
 # Auscope-portal-api access - https://code.google.com/apis/console/#project:967189472827
 auscope-portal-dev.googlemap.key=AIzaSyBArcbrWG8q6cUeP4WrhD3-s1D0aYbkxfA
 auscope-portal-dev.vocabService.url=http://auscope-services-test.arrc.csiro.au/sissvoc/

--- a/src/main/webapp/WEB-INF/auscope-known-layers.xml
+++ b/src/main/webapp/WEB-INF/auscope-known-layers.xml
@@ -586,6 +586,37 @@
         </property>
     </bean>
 
+    <bean id="knownTypeGeologicalProvinceContact" class="org.auscope.portal.core.view.knownlayer.KnownLayer">
+        <constructor-arg name="id" value="geologicalProvinceContacts"/>
+        <constructor-arg name="knownLayerSelector">
+            <bean class="org.auscope.portal.core.view.knownlayer.WMSSelector">
+                <constructor-arg name="layerName" value="ProvinceContacts"/>
+            </bean>
+        </constructor-arg>
+        <property name="name" value="Province Contacts"/>
+        <property name="description" value="Contacts (boundaries) of the full spatial extent of Australia's geological provinces. 
+        	Where possible, the contacts of provinces have been attributed with information about the source, accuracy, and observation method of those lines."/>
+        <property name="group" value="Geological Provinces"/>
+        <property name="proxyUrl" value=""/>
+        <property name="proxyCountUrl" value=""/>
+    </bean>
+    
+    <bean id="knownTypeGeologicalProvinceMetallogenic" class="org.auscope.portal.core.view.knownlayer.KnownLayer">
+        <constructor-arg name="id" value="geologicalProvinceMetallogenic"/>
+        <constructor-arg name="knownLayerSelector">
+            <bean class="org.auscope.portal.core.view.knownlayer.WMSSelector">
+                <constructor-arg name="layerName" value="MetallogenicProvinces"/>
+            </bean>
+        </constructor-arg>
+        <property name="name" value="Metallogenic Provinces"/>
+        <property name="description" value="Descriptions and spatial extents of metallogenic provinces of the Australian continent."/>
+        <property name="group" value="Geological Provinces"/>
+        <property name="proxyUrl" value=""/>
+        <property name="proxyCountUrl" value=""/>
+    </bean>
+
+<!-- HEYADO more geological provinces layers -->
+
     <bean id="knownTypeAster" class="org.auscope.portal.core.view.knownlayer.KnownLayer">
         <constructor-arg name="id" value="aster-main"/>
         <constructor-arg name="knownLayerSelector">

--- a/src/main/webapp/WEB-INF/auscope-registries.xml
+++ b/src/main/webapp/WEB-INF/auscope-registries.xml
@@ -7,6 +7,20 @@
        http://www.springframework.org/schema/tx
        http://www.springframework.org/schema/tx/spring-tx-2.5.xsd">
 
+    <bean id="cswGeoscienceLocal" class="org.auscope.portal.core.services.csw.CSWServiceItem">
+        <constructor-arg name="id" value="cswGeoscienceLocal"/>
+        <constructor-arg name="title" value="Geoscience developer Geonetwork"/>
+        <constructor-arg name="serviceUrl" value="http://localhost:8080/geonetwork/srv/eng/csw"/>
+        <constructor-arg name="recordInformationUrl" value="http://localhost:8080/geonetwork/srv/eng/main.home?uuid=%1$s"/>
+    </bean>
+
+    <bean id="cswGeoscienceDev" class="org.auscope.portal.core.services.csw.CSWServiceItem">
+        <constructor-arg name="id" value="cswGeoscienceDev"/>
+        <constructor-arg name="title" value="Geoscience Dev Geonetwork"/>
+        <constructor-arg name="serviceUrl" value="http://54.206.17.34:8080/geonetwork/srv/eng/csw"/>
+        <constructor-arg name="recordInformationUrl" value="http://54.206.17.34:8080/geonetwork/srv/eng/main.home?uuid=%1$s"/>
+    </bean>
+    
     <bean id="cswAuscopeTest" class="org.auscope.portal.core.services.csw.CSWServiceItem">
         <constructor-arg name="id" value="cswAuscopeTest"/>
         <constructor-arg name="title" value="AuScope Test Geonetwork"/>

--- a/src/main/webapp/WEB-INF/profile-portal-test.xml
+++ b/src/main/webapp/WEB-INF/profile-portal-test.xml
@@ -42,6 +42,8 @@
                 <ref bean="knownTypeHighPSitePhosLayer"/>
                 <ref bean="knownTypePortals"/>
                 <ref bean="knownTypeGeoNetworks"/>
+                	<ref bean="knownTypeGeologicalProvinceContact" />
+                    <ref bean="knownTypeGeologicalProvinceMetallogenic" />
                 <ref bean="knownTypeAster" />
                 <ref bean="knownTypeAsterAloh" />
                 <ref bean="knownTypeAsterFerrous" />
@@ -95,6 +97,8 @@
     <bean id="cswServiceList" class="java.util.ArrayList">
         <constructor-arg>
             <list>
+                <!-- <ref bean="cswGeoscienceLocal" />-->
+                <ref bean="cswGeoscienceDev" /> 
                 <ref bean="cswAuscopeTest" />
                 <ref bean="cswInSarProduction" />
                 <ref bean="cswMDUTest" />


### PR DESCRIPTION
The first two layers of Geological Provinces added to the UI. As far as I can tell they are complete, but further work may reveal issues (for example, the next issue I'm thinking of looking at is the service details dialog, if there are issues with the service URLs or whatever then I should notice).
The rest of the Geological Provinces layers should be added under a new Jira once the sort order issue has been resolved and merged.
